### PR TITLE
[8.0][FIX] l10n_es_aeat_mod340: Correccion de calculo de records de facturas

### DIFF
--- a/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
+++ b/l10n_es_aeat_mod340/wizard/calculate_mod340_records.py
@@ -240,9 +240,9 @@ class L10nEsAeatMod340CalculateRecords(models.TransientModel):
             if tot_invoice != invoice.cc_amount_total:
                 values['total'] = tot_invoice
             if invoice.type in ['out_invoice', 'out_refund']:
-                invoices340.write(invoice_created)
+                invoice_created.write(values)
             if invoice.type in ['in_invoice', 'in_refund']:
-                invoices340_rec.write(invoice_created)
+                invoice_created.write(values)
             rec_tax_invoice = 0
             for surcharge in surcharge_taxes_lines:
                 rec_tax_percentage = round(surcharge.amount /


### PR DESCRIPTION
Se corrige un error en el código del cálculo de los records de factura del modelo 340.